### PR TITLE
FIX: Allow lookup of _scaling_ values in GQL

### DIFF
--- a/api/pages/api/graphql/typeDef.js
+++ b/api/pages/api/graphql/typeDef.js
@@ -1,8 +1,8 @@
 import { gql } from "apollo-server-micro";
 
 export const typeDefs = gql`
-  type ScallingEntry {
-    scalling: String
+  type ScalingEntry {
+    scaling: String
     name: String
   }
 
@@ -125,7 +125,7 @@ export const typeDefs = gql`
     description: String
     attack: [AttributeEntry]
     defence: [AttributeEntry]
-    scalesWith: [ScallingEntry]
+    scalesWith: [ScalingEntry]
     requiredAttributes: [AttributeEntry]
     category: String
     weight: Int
@@ -168,7 +168,7 @@ export const typeDefs = gql`
     description: String
     attack: [AttributeEntry]
     defence: [AttributeEntry]
-    scalesWith: [ScallingEntry]
+    scalesWith: [ScalingEntry]
     requiredAttributes: [AttributeEntry]
     category: String
     weight: Int

--- a/docs/docs/shields.md
+++ b/docs/docs/shields.md
@@ -22,7 +22,7 @@ This route fetches a list of all Shields that can be obtained in Elden Ring, and
 | attack         | `{ name: string, amount: number }` | How much damage the Shield does when used as a weapon  |
 | defence         | `{ name: string, amount: number }` | How much damage the Shield blocks when used as a shield  |
 | requiredAttributes         | `{ name: string, amount: number }` | What are the required attribute amount in order to properly use this shield. Example: `{ name: "Str", amount: 20 }`  |
-| scalesWith         | `{ name: string, scaling: string }` | How much the shield scales and with what attributes. Example: `{ name: "Str", scalling: "B" }`  |
+| scalesWith         | `{ name: string, scaling: string }` | How much the shield scales and with what attributes. Example: `{ name: "Str", scaling: "B" }`  |
 
 ## Sample Result
 

--- a/docs/docs/weapons.md
+++ b/docs/docs/weapons.md
@@ -22,7 +22,7 @@ This route fetches a list of all Weapons that can be obtained in Elden Ring, and
 | attack         | `{ name: string, amount: number }` | How much damage the Weapon does when used as a weapon  |
 | defence         | `{ name: string, amount: number }` | How much damage the Weapon blocks when used to defend an attack  |
 | requiredAttributes         | `{ name: string, amount: number }` | What are the required attribute amount in order to properly use this Weapon. Example: `{ name: "Str", amount: 20 }`  |
-| scalesWith         | `{ name: string, scaling: string }` | How much the Weapon scales and with what attributes. Example: `{ name: "Str", scalling: "B" }`  |
+| scalesWith         | `{ name: string, scaling: string }` | How much the Weapon scales and with what attributes. Example: `{ name: "Str", scaling: "B" }`  |
 
 ## Sample Result
 


### PR DESCRIPTION
> A typo in a GQL field leads to an attempted lookup of a nonexistent JSON
> key. Update the schema and corresponding documentation.

Loving the API! I noticed scaling tiers were returning `null` from the GQL endpoint- looks like a little typo:

#### Request
```sh
# extra L in `scalling`, as defined in GQL schema
curl 'https://eldenring.fanapis.com/api/graphql' -H 'Content-Type: application/json' --data-binary '{"query":"{getWeapon(id:\"17f69d12746l0i1ojbzxzgz6gfjsi\"){name scalesWith{name scalling}}}"}'
```
#### Response
```json
{"data":{"getWeapon":{"name":"Longbow","scalesWith":[{"name":"Str","scalling":null},{"name":"Dex","scalling":null}]}}}
```